### PR TITLE
[BAD-238] updated the sankey path tooltip

### DIFF
--- a/es6/chart/Sankey.js
+++ b/es6/chart/Sankey.js
@@ -346,11 +346,12 @@ var getPayloadOfTooltip = function getPayloadOfTooltip(el, type, nameKey) {
   if (payload.source && payload.target) {
     var sourceName = getValueByDataKey(payload.source, nameKey, '');
     var targetName = getValueByDataKey(payload.target, nameKey, '');
+    var value = (getValueByDataKey(payload, 'value') * 100).toFixed(0);
 
     return [{
       payload: el,
-      name: sourceName + ' - ' + targetName,
-      value: getValueByDataKey(payload, 'value')
+      name: 'Percent of users who proceeded from ' + sourceName + ' to ' + targetName,
+      value: value + '%'
     }];
   }
 

--- a/es6/chart/Sankey.js
+++ b/es6/chart/Sankey.js
@@ -350,8 +350,8 @@ var getPayloadOfTooltip = function getPayloadOfTooltip(el, type, nameKey) {
 
     return [{
       payload: el,
-      name: 'Percent of users who proceeded from ' + sourceName + ' to ' + targetName,
-      value: value + '%'
+      name: value + '% of users proceeded from \'' + sourceName + '\' to \'' + targetName + '\'',
+      value: ''
     }];
   }
 
@@ -633,6 +633,7 @@ var Sankey = pureRender(_class = (_temp = _class2 = function (_Component) {
         active: isTooltipActive,
         coordinate: coordinate,
         label: '',
+        separator: '',
         payload: payload
       });
     }

--- a/src/chart/Sankey.js
+++ b/src/chart/Sankey.js
@@ -306,8 +306,8 @@ const getPayloadOfTooltip = (el, type, nameKey) => {
 
     return [{
       payload: el,
-      name: `Percent of users who proceeded from ${sourceName} to ${targetName}`,
-      value: `${value}%`
+      name: `${value}% of users proceeded from '${sourceName}' to '${targetName}'`,
+      value: ''
     }];
   }
 
@@ -585,6 +585,7 @@ class Sankey extends Component {
       active: isTooltipActive,
       coordinate,
       label: '',
+      separator: '',
       payload,
     });
   }

--- a/src/chart/Sankey.js
+++ b/src/chart/Sankey.js
@@ -302,11 +302,12 @@ const getPayloadOfTooltip = (el, type, nameKey) => {
   if (payload.source && payload.target) {
     const sourceName = getValueByDataKey(payload.source, nameKey, '');
     const targetName = getValueByDataKey(payload.target, nameKey, '');
+    const value = (getValueByDataKey(payload, 'value') * 100).toFixed(0);
 
     return [{
       payload: el,
-      name: `${sourceName} - ${targetName}`,
-      value: getValueByDataKey(payload, 'value'),
+      name: `Percent of users who proceeded from ${sourceName} to ${targetName}`,
+      value: `${value}%`
     }];
   }
 


### PR DESCRIPTION
Updated the path tooltip of the Sankey diagram. 

After synced with Marketing team, we propose the text showing on the screenshot below over the current version of copy.

Before:
![screen shot 2018-08-17 at 11 41 10 am](https://user-images.githubusercontent.com/5857519/44283197-76244680-a212-11e8-9672-da35a21166a2.png)


After: 
![screen shot 2018-08-17 at 11 34 48 am](https://user-images.githubusercontent.com/5857519/44282980-ae775500-a211-11e8-9253-56dd87a464d3.png)
